### PR TITLE
redirect to download adjusted

### DIFF
--- a/aasp/urls.py
+++ b/aasp/urls.py
@@ -15,13 +15,15 @@ Including another URLconf
 """
 from django.urls import include, path
 from django.contrib import admin
+from django.views.generic import RedirectView
 
 from files.views import DownloadView
 
 
 urlpatterns = [
+    path('', RedirectView.as_view(url='files/')),
     path('admin/', admin.site.urls),
     path('files/', include('files.urls')),
     path('analyze/', include('analyze.urls')),
-    path('download/', DownloadView.as_view(), name='download'),
+    path('download/<slug:method>', DownloadView.as_view(), name='download'),
 ]

--- a/analyze/views.py
+++ b/analyze/views.py
@@ -41,7 +41,7 @@ class AnalyzeView(TemplateView):
             for item_id in analysis_set:
                 item = item_list.get(pk=item_id)
                 analyze_ToDI(item)
-            return HttpResponseRedirect('../download/')
+            return HttpResponseRedirect('../download/AuToDI')
         elif 'fda' in request.POST:
             with open(csv_file_name, 'w') as f:        
                 csv_writer = csv.DictWriter(f, 
@@ -126,7 +126,7 @@ class FDASmoothingView(View):
         knots = request.POST.get('knots')
         call = ["Rscript", "--vanilla", "FDA/FPCA.R", lam, knots]
         output = subprocess.check_output(call)
-        return HttpResponse(' '.join([lam, knots]))
+        return HttpResponseRedirect('../download/FDA')
 
 
 def get_tg_name(filename):

--- a/files/templates/files/base.html
+++ b/files/templates/files/base.html
@@ -19,26 +19,15 @@
                     <strong class="navbar-item">
                         AASP
                     </strong>
-        
-                    <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false"
-                        data-target="navbarBasicExample" (click)="toggleBurger()"
-                        [ngClass]="{'is-active': burgerActive}">
-                        <span aria-hidden="true"></span>
-                        <span aria-hidden="true"></span>
-                        <span aria-hidden="true"></span>
-                    </a>
                 </div>
         
-                <div id="navbarBasicExample" class="navbar-menu" [ngClass]="{'is-active': burgerActive}" [@slideInOut]="burgerShow">
+                <div id="navbarAASP" class="navbar-menu" [ngClass]="{'is-active': burgerActive}" [@slideInOut]="burgerShow">
                     <div class="navbar-start">
                         <a class="navbar-item" href="/files">
                             Files
                         </a>
                         <a class="navbar-item" href="/analyze">
                             Analysis
-                        </a>
-                        <a class="navbar-item" href="/download">
-                            Download
                         </a>
                     </div>
                 </div>

--- a/files/views.py
+++ b/files/views.py
@@ -1,6 +1,7 @@
 
 from collections import Counter
 from zipfile import ZipFile
+import os
 import os.path as op
 import io
 import glob
@@ -42,11 +43,13 @@ class ProvideFilesView(FormView):
 class DownloadView(TemplateView):
     template_name = 'files/download.html'
     
-    def post(self, request, *args, **kwargs):
+    def post(self, request, method, *args, **kwargs):
         s = io.BytesIO()
         zf = ZipFile(s, "w")
-        for analyzed_file in glob.glob('output/*.TextGrid'):
+        output_selector = '{}_output/*.*'.format(method)
+        for analyzed_file in glob.glob(output_selector):
             zf.write(analyzed_file)
+            os.remove(analyzed_file)
         zf.close()
         response = HttpResponse(s.getvalue(), content_type="application/x-zip-compressed")
         response['Content-Disposition'] = 'attachment; filename=results.zip'


### PR DESCRIPTION
This branch
- adds a url argument to the download path, so that FDA / AuToDI data are downloaded selectively
- empties the respective output folders after zipping the download output
- removes the defunct burger menu from `base.html`
- removes the download link from the navbar (without 'FDA / AuToDI', it doesn't work, and the folders will be empty in most cases)
- redirects the user to the `/files` subpath from the main path