### PR TITLE
Fix Django widget for multiple files

### DIFF
--- a/files/forms.py
+++ b/files/forms.py
@@ -1,6 +1,22 @@
 from django import forms
 
+
+class MultipleFileInput(forms.ClearableFileInput):
+    allow_multiple_selected = True
+
+class MultipleFileField(forms.FileField):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("widget", MultipleFileInput())
+        super().__init__(*args, **kwargs)
+
+    def clean(self, data, initial=None):
+        single_file_clean = super().clean
+        if isinstance(data, (list, tuple)):
+            result = [single_file_clean(d, initial) for d in data]
+        else:
+            result = [single_file_clean(data, initial)]
+        return result
+
 class SpeakerDirectoryForm(forms.Form):
     label = forms.CharField(required=True)
-    files = forms.FileField(widget=forms.ClearableFileInput(attrs=
-        {'multiple': True}))
+    files = MultipleFileField()


### PR DESCRIPTION
User reported application not starting after last update, corrobrated that.

This PR uses Django's proposed implementation for [multiple uploads widget ](https://docs.djangoproject.com/en/3.2/topics/http/file-uploads/#uploading-multiple-files). It is a little bit hard for me to confirm if this works correctly. The application runs and I can upload multiple files. However, the analysis returns errors, which may be unrelated. Was also some hassle involved with getting Docker-compose setup to work on my M1 Mac, so that may cause this.

For now: please confirm this works, we can work on a working local installation for me later.